### PR TITLE
Sözlüğe 2 kelime ekle

### DIFF
--- a/ceviri/sozluk.md
+++ b/ceviri/sozluk.md
@@ -192,6 +192,8 @@ Group: Grup, Grupla (Kimi yerlerde “Küme” yeğlenmiştir)
 
 Hash: Özet
 
+Header: Başlık
+
 Hibernate: Hazırda beklet
 
 Host: Ana makine
@@ -285,6 +287,8 @@ Online: Çevrim içi
 Only: Yalnızca
 
 Or: Ya da
+
+Outline: Anahat
 
 Output: Çıktı
 


### PR DESCRIPTION
Header çevirileri arada üstbilgi olarak çevrilmişti. Proje genelinde düzeltildi ve sözcük buraya not olarak eklendi.

Outline çevirileri de farklılık gösteriyordu. Anahat olarak çevrildi ve buraya not olarak eklendi.